### PR TITLE
Fix UseWeatherForecastByCityName to UseOpenWeatherByCityName in appsettings.json.

### DIFF
--- a/sample/FeatureToggleApp/appsettings.json
+++ b/sample/FeatureToggleApp/appsettings.json
@@ -3,7 +3,7 @@
     // Использовать заглушку для внешней зависимости OpenWeather.
     "UseOpenWeatherStub": false,
     // Использовать конечную точку 'by-name'.
-    "UseWeatherForecastByCityName": false,
+    "UseOpenWeatherByCityName": false,
 
     // При запуске сервиса: подавлять авторизацию.
     "OnStart_SuppressAuth": false


### PR DESCRIPTION
Fix FeatureManagement:UseWeatherForecastByCityName to FeatureManagement:UseOpenWeatherByCityName in appsettings.json.